### PR TITLE
fix: Safari problem fixed

### DIFF
--- a/components/layout/layout.component.jsx
+++ b/components/layout/layout.component.jsx
@@ -4,7 +4,7 @@ import Bar from "../bar/bar.component";
 import Announcement from "./announcement/announcement.component";
 import Footer from "./footer/footer.component";
 import NavBar from "./nav-bar/nav-bar.component";
-import SideNavBar from "./side-nav-bar/side-nav-bar.component";
+import SideBar from "./side-bar/side-bar.component";
 import HamburgerButton from "../hamburger-button/hamburger-button.component";
 
 import { useMediaQuery } from "react-responsive";
@@ -71,7 +71,7 @@ export default function Layout({ children }) {
           )}
         </Bar>
       </Announcement>
-      <SideNavBar
+      <SideBar
         isOpen={isOpen}
         hamburgerButton={
           <HamburgerButton onClickHandler={onClickHandler} menuActive={true} />

--- a/components/layout/side-bar/side-bar.component.jsx
+++ b/components/layout/side-bar/side-bar.component.jsx
@@ -1,13 +1,12 @@
 import classNames from "classnames";
 import MenuItem from "../../menu-item/menu-item.component";
-import Logo from "../../logo/logo.component";
-import "./side-nav-bar.style.scss";
+import "./side-bar.style.scss";
 
-export default function SideNavBar({ hamburgerButton, isOpen }) {
+export default function SideBar({ hamburgerButton, isOpen }) {
   return (
     <div
-      className={classNames("sidenavbar__container", {
-        "sidenavbar__container--active": isOpen,
+      className={classNames("sidebar__container", {
+        "sidebar__container--active": isOpen,
       })}
     >
       <div className="sidebar__top">{hamburgerButton}</div>

--- a/components/layout/side-bar/side-bar.style.scss
+++ b/components/layout/side-bar/side-bar.style.scss
@@ -1,6 +1,6 @@
 @import "../../../global/variables.scss";
 
-.sidenavbar__container {
+.sidebar__container {
   padding: 2rem 1.5rem 0.5rem 1.5rem;
   background-color: $background-color;
   border-left: 1px solid $border-color;

--- a/components/layout/side-bar/side-bar.style.scss
+++ b/components/layout/side-bar/side-bar.style.scss
@@ -11,6 +11,7 @@
   transition: all 0.5s ease 0s;
   overflow-y: auto;
   z-index: 999;
+  top: 0;
 
   &--active {
     right: 0;
@@ -66,6 +67,7 @@
   }
 
   @media only screen and (max-width: $max-width-mobile) {
+    top: 2.4rem;
     width: 100%;
     border-left: unset;
   }


### PR DESCRIPTION
🥃 #13 Design SideBar 🥃
- [x] Show Sidebar onClick event (on navbar)
- [x] Close Sidebar onClick event (on sidebar)
- [ ] Design Sidebar
   - [ ] Add Karsal Logo
   - [ ] Add CSS to MenuItems
   - [x] Stop Scroll event while Sidebar is shown
   - [x] Add transition animations
- [ ] Test Responsiveness
  - [x] Fix problem with laptop size (Navbar is not shown)
  - [ ] When clicking to the sidebar button at the bottom of page, it goes to top.
  - [x] In IOS (Safari), user still can scroll down which leads problems.
  - [ ] SideBar is not acting normally in portrait mode (look for overflow-y value)
  - [x] Set top:0
- General Test
   - [ ] Opening and closing SideBar after scrolling down causes some problems