### PR TITLE
[#13] style(sidebar): languages added to menu

### DIFF
--- a/components/layout/side-bar/side-bar.component.jsx
+++ b/components/layout/side-bar/side-bar.component.jsx
@@ -12,10 +12,12 @@ export default function SideBar({ hamburgerButton, isOpen }) {
       <div className="sidebar__container">
         <div className="sidebar__top">{hamburgerButton}</div>
         <div className="sidebar__body">
-          <MenuItem href="/hakkımızda">HAKKIMIZDA</MenuItem>
-          <MenuItem href="/iletişim">İLETİŞİM</MenuItem>
+          <MenuItem href="/hakkimizda">HAKKIMIZDA</MenuItem>
+          <MenuItem href="/iletisim">İLETİŞİM</MenuItem>
           <MenuItem href="/fabrika">FABRİKA</MenuItem>
           <MenuItem href="/katalog">KATALOG</MenuItem>
+          <MenuItem href="/">TÜRKÇE</MenuItem>
+          <MenuItem href="/">ENGLISH</MenuItem>
         </div>
         <div className="sidebar__footer">
           <span>

--- a/components/layout/side-bar/side-bar.style.scss
+++ b/components/layout/side-bar/side-bar.style.scss
@@ -40,7 +40,7 @@
       align-items: center;
       flex-direction: column;
       justify-content: space-around;
-      height: 50vh;
+      height: 70vh;
 
       li {
         padding-top: 1rem;
@@ -50,13 +50,14 @@
         padding-bottom: 5px;
         border-bottom: 2px solid $border-color;
         transition: all 0.5s ease 0s;
+        margin-bottom: 0.5rem;
 
         &:hover {
           transform: translateX(1rem);
         }
 
         a {
-          font-size: 2rem;
+          font-size: 1.7rem;
           font-family: "SuisseInt-Regular";
           font-weight: 200;
 
@@ -83,6 +84,10 @@
         flex-direction: column;
         align-items: center;
         padding-right: 0;
+      }
+
+      @media only screen and (max-width: $max-width-mobile) {
+        padding-bottom: 1rem;
       }
     }
   }


### PR DESCRIPTION
🥃 #13 Design SideBar 🥃
- [x] Show Sidebar onClick event (on navbar)
- [x] Close Sidebar onClick event (on sidebar)
- [x] Refactor Sass
- [ ] Add gestures for mobile (pan-right, pan-left)
- [ ] Design Sidebar
   - [ ] Add Karsal Logo
   - [ ] Add CSS to MenuItems
   - [x] Add language options.
   - [x] Stop Scroll event while Sidebar is shown
   - [x] Add transition animations
- [x] Test Responsiveness
  - [x] Fix problem with laptop size (Navbar is not shown)
  - [x] When clicking to the sidebar button at the bottom of page, it goes to top.
  - [x] In IOS (Safari), user still can scroll down which leads problems.
  - [x] SideBar is not acting normally in portrait mode (look for overflow-y value)
  - [x] Set top:0
- [x] General Test
   - [x] Opening and closing SideBar after scrolling down causes some problems
